### PR TITLE
[patch 2/4][upstart] Manage contrail-compute upstart and contrail-discovery-server

### DIFF
--- a/debian/contrail/debian/contrail-compute.upstart
+++ b/debian/contrail/debian/contrail-compute.upstart
@@ -1,0 +1,16 @@
+description "Contrail agent"
+author "OpenContrail <dev@lists.opencontrail.org>"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+
+respawn
+
+script
+       COMMAND=/usr/bin/vnswad
+       OPTS="--conf-file /etc/contrail/agent.conf"
+       if [ -f /etc/default/$UPSTART_JOB ]; then
+               . /etc/default/$UPSTART_JOB
+       fi
+        "$COMMAND" $OPTS
+end script

--- a/debian/contrail/debian/contrail-config.contrail-api.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-api.upstart
@@ -1,4 +1,5 @@
 description "Contrail API server"
+author "OpenContrail <dev@lists.opencontrail.org>"
 
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]

--- a/debian/contrail/debian/contrail-config.contrail-discovery-server.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-discovery-server.upstart
@@ -1,0 +1,16 @@
+description "Contrail Discovery server"
+author "OpenContrail <dev@lists.opencontrail.org>"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+
+respawn
+
+script
+       COMMAND=/usr/bin/discovery-server
+       OPTS="--conf_file /etc/contrail/discovery.conf"
+       if [ -f /etc/default/$UPSTART_JOB ]; then
+               . /etc/default/$UPSTART_JOB
+       fi
+        "$COMMAND" $OPTS
+end script

--- a/debian/contrail/debian/contrail-config.contrail-schema.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-schema.upstart
@@ -1,4 +1,5 @@
 description "Contrail API server"
+author "OpenContrail <dev@lists.opencontrail.org>"
 
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]

--- a/debian/contrail/debian/contrail-config.contrail-svc-monitor.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-svc-monitor.upstart
@@ -1,4 +1,5 @@
 description "Contrail VNC Service Monitor"
+author "OpenContrail <dev@lists.opencontrail.org>"
 
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]

--- a/debian/contrail/debian/contrail-config.discovery-server.upstart
+++ b/debian/contrail/debian/contrail-config.discovery-server.upstart
@@ -1,4 +1,5 @@
 description "Contrail discovery server"
+author "OpenContrail <dev@lists.opencontrail.org>"
 
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]

--- a/debian/contrail/debian/contrail-control.upstart
+++ b/debian/contrail/debian/contrail-control.upstart
@@ -1,4 +1,5 @@
 description "Contrail Control Node"
+author "OpenContrail <dev@lists.opencontrail.org>"
 
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]

--- a/debian/contrail/debian/rules
+++ b/debian/contrail/debian/rules
@@ -17,3 +17,4 @@ override_dh_installinit:
 	dh_installinit --name=contrail-api
 	dh_installinit --name=contrail-schema
 	dh_installinit --name=discovery-server
+	dh_installinit --name=contrail-discovery


### PR DESCRIPTION
Manage contrail-compute upstart and contrail-discovery-server
- /etc/contrail/agent.conf isn't yet managed on contrail-agent
