### PR TITLE
Add Suresh's patch to segment ifmap results

### DIFF
--- a/debian/ifmap-server/debian/patches/002_ifmap_split_results.patch
+++ b/debian/ifmap-server/debian/patches/002_ifmap_split_results.patch
@@ -1,0 +1,677 @@
+diff --git a/ifmap.properties b/ifmap.properties
+index ed57a69..280b515 100644
+--- a/ifmap.properties
++++ b/ifmap.properties
+ # The default max-size value for search requests in bytes
+ irond.ifmap.default.searchresultsize=100000
+
++# Limit the size of a search result
++irond.ifmap.default.maxperpollresultsize=8192
++irond.ifmap.default.splitinitialsearchresult=true
++irond.ifmap.default.droponresultstoobig=false
++
+ # If this is true, only purging of the own metadata is possible
+ irond.ifmap.restrict.purgepublisher=true
+diff --git a/schema/ifmap-base-2.0v17.xsd b/schema/ifmap-base-2.0v17.xsd
+index c3ca23a..ac11a98 100644
+--- a/schema/ifmap-base-2.0v17.xsd
++++ b/schema/ifmap-base-2.0v17.xsd
+@@ -113,6 +113,7 @@
+ 
+   <xsd:complexType name="NewSessionRequestType">
+     <xsd:attribute name="max-poll-result-size" type="xsd:integer" use="optional"/>
++    <xsd:attribute name="max-per-poll-result-size" type="xsd:integer" use="optional"/>
+   </xsd:complexType>
+ 
+   <xsd:attributeGroup name="validationAttributes">
+@@ -383,6 +384,7 @@
+     <xsd:attribute name="session-id" type="xsd:string" use="required"/>
+     <xsd:attribute name="ifmap-publisher-id" type="xsd:string" use="required"/>
+     <xsd:attribute name="max-poll-result-size" type="xsd:integer" use="optional"/>
++    <xsd:attribute name="max-per-poll-result-size" type="xsd:integer" use="optional"/>
+   </xsd:complexType>
+ 
+   <!-- ResponseType encapsulates results from all the different
+diff --git a/src/de/fhhannover/inform/iron/mapserver/binding/JaxbRequestUnmarshaller.java b/src/de/fhhannover/inform/iron/mapserver/binding/JaxbRequestUnmarshaller.java
+index 395148b..a1f5637 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/binding/JaxbRequestUnmarshaller.java
++++ b/src/de/fhhannover/inform/iron/mapserver/binding/JaxbRequestUnmarshaller.java
+@@ -332,8 +332,10 @@ class JaxbRequestUnmarshaller implements RequestUnmarshaller {
+ 	private NewSessionRequest transformNewSessionRequest(NewSessionRequestType newSession)
+ 			throws RequestCreationException {
+ 		BigInteger mprsRrecv = newSession.getMaxPollResultSize();
++                BigInteger mpprsRrecv = newSession.getMaxPerPollResultSize();
+ 		Integer mprs = (mprsRrecv == null) ? null : new Integer(mprsRrecv.intValue());
+-		return requestFactory.createNewSessionRequest(mprs);
++                Integer mpprs = (mpprsRrecv == null) ? null : new Integer(mpprsRrecv.intValue());
++		return requestFactory.createNewSessionRequest(mprs, mpprs);
+ 	}
+ 
+ 	private PollRequest transformPollRequest(PollRequestType poll)
+diff --git a/src/de/fhhannover/inform/iron/mapserver/communication/ifmap/EventProcessor.java b/src/de/fhhannover/inform/iron/mapserver/communication/ifmap/EventProcessor.java
+index c3dda2f..4953aef 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/communication/ifmap/EventProcessor.java
++++ b/src/de/fhhannover/inform/iron/mapserver/communication/ifmap/EventProcessor.java
+@@ -1101,7 +1101,7 @@ public class EventProcessor extends Processor<Event> {
+ 		mSessionRep.map(session, channelId);
+ 		mSessionRep.map(session, sessionId);
+ 		
+-		mDataModel.newSession(sessionId, publisherId, request.getMaxPollResultSize());
++		mDataModel.newSession(sessionId, publisherId, request.getMaxPollResultSize(), request.getMaxPerPollResultSize());
+ 		
+ 		return session;
+ 	}
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/ClientService.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/ClientService.java
+index ce7140e..08f018a 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/ClientService.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/ClientService.java
+@@ -64,13 +64,15 @@ class ClientService {
+ 	 * @throws RunningSessionException newSession is called, the publisher exists
+ 	 * 			but had never received an end session call
+ 	 */
+-	void newSession(String sessionId, String publisherId, Integer mprs) {
++	void newSession(String sessionId, String publisherId, Integer mprs, Integer mpprs) {
+ 		if (mprs == null)
+ 			mprs = new Integer(DataModelService.getServerConfiguration().getDefaultMaxPollResultSize());
++                if (mpprs == null)
++                        mpprs = new Integer(DataModelService.getServerConfiguration().getDefaultMaxPerPollResultSize());
+ 		sLogger.trace(sName + ": newSession for " + publisherId 
+-				+ " and maxPollResultSize=" + mprs + " bytes");
++                                + " and maxPollResultSize=" + mprs + " bytes and maxPerPollResultSize=" + mpprs);
+ 	
+-		publisherRep.addPublisher(publisherId, sessionId, mprs);
++		publisherRep.addPublisher(publisherId, sessionId, mprs, mpprs);
+ 	}
+ 	 
+ 	/**
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/DataModelService.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/DataModelService.java
+index 5404343..b7a1a6e 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/DataModelService.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/DataModelService.java
+@@ -160,10 +160,10 @@ public class DataModelService implements SubscriptionNotifier {
+ 		clientService.purgePublisher(sessionId, publisherId);
+ 	}
+ 	
+-	synchronized public void newSession(String sessionId, String publisherId, Integer mprs) {
++	synchronized public void newSession(String sessionId, String publisherId, Integer mprs, Integer mpprs) {
+ 		checkNull(sessionId);
+ 		checkNull(publisherId);
+-		clientService.newSession(sessionId, publisherId, mprs);
++		clientService.newSession(sessionId, publisherId, mprs, mpprs);
+ 	}
+ 	 
+ 	synchronized public void endSession(String sessionId) {
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/Publisher.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/Publisher.java
+index 87327a4..6178c84 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/Publisher.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/Publisher.java
+@@ -63,7 +63,7 @@ public class Publisher {
+ 	
+ 	private SubscriptionState mSubscriptionState;
+ 	
+-	public Publisher(String publisherId, String sessionId, Integer mprs) {
++	public Publisher(String publisherId, String sessionId, Integer mprs, Integer mpprs) {
+ 		
+ 		NullCheck.check(publisherId, "publisherId is null");
+ 		NullCheck.check(sessionId, "sessionId is null");
+@@ -77,6 +77,7 @@ public class Publisher {
+ 		mSessionId = sessionId;
+ 		
+ 		mSubscriptionState.setMaxPollResultSize(mprs);
++                mSubscriptionState.setMaxPerPollResultSize(mpprs);
+ 	}
+ 	 
+ 	
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/PublisherRep.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/PublisherRep.java
+index 6b08de6..d181650 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/PublisherRep.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/PublisherRep.java
+@@ -108,7 +108,7 @@ class PublisherRep {
+ 	 * @throws RunningSessionException
+ 	 * @throws PublisherConstructionException
+ 	 */
+-	void addPublisher(String publisherId, String sessionId, Integer maxPollResSize) {
++	void addPublisher(String publisherId, String sessionId, Integer maxPollResSize, Integer maxPerPollResSize) {
+ 		
+ 		logger.trace("Adding new Publisher: sessionid=" + sessionId + 
+ 				" publisherid=" + publisherId);
+@@ -122,10 +122,11 @@ class PublisherRep {
+ 			
+ 			logger.trace("Reusing existing publisher object...");
+ 			p.getSubscriptionState().setMaxPollResultSize(maxPollResSize);
++                        p.getSubscriptionState().setMaxPerPollResultSize(maxPerPollResSize);
+ 			
+ 		} else {
+ 			logger.trace("Creating new Publisher...");
+-			p = new Publisher(publisherId, sessionId, maxPollResSize);
++			p = new Publisher(publisherId, sessionId, maxPollResSize, maxPerPollResSize);
+ 			publishers.put(publisherId, p);
+ 		}
+ 		
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java
+index 094653a..8954e00 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java
+@@ -209,7 +209,7 @@ public class SubscriptionService {
+ 	
+ 		try {
+ 			ModifiableSearchResult initResult = runInitialSearch(sub);
+-			subState.getPollResult().addSearchResult(initResult);
++			subState.getPollResult().addSearchResult(initResult, subState.getMaxPerPollResultSize());
+ 		} catch (SearchResultsTooBigException e) {
+ 			sub.setExceededSize();
+ 			subState.getPollResult().addErrorResult(sub.getName());
+@@ -237,7 +237,7 @@ public class SubscriptionService {
+ 		Set<MetadataHolder> newMeta = CollectionHelper.provideSetFor(MetadataHolder.class);
+ 		Set<Node> starters = CollectionHelper.provideSetFor(Node.class);
+ 		ModifiableSearchResult initSres = mSearchFac.newCopySearchResult(sub.getName());
+-		
++	        initSres.setSearchTypeInitialRun(true);	
+ 		SearchHandler handler = mSearchFac.newContinueSearchHandler(
+ 				sub.getSearchRequest().getStartIdentifier(),
+ 				0,
+@@ -327,7 +327,7 @@ public class SubscriptionService {
+ 		for (MetadataHolder mh : results)
+ 			sres.addMetadata(mh.getGraphElement(), mh.getMetadata());
+ 
+-		state.getPollResult().addSearchResult(sres);
++		state.getPollResult().addSearchResult(sres, state.getMaxPerPollResultSize());
+ 
+ 		setHasChanges(sub);
+ 	}
+@@ -812,7 +812,7 @@ public class SubscriptionService {
+ 		if (!subState.isNotified()) {
+ 			sLogger.trace(sName + ": " + pub.getPublisherId() + 
+ 					" has new poll results");
+-			subState.setNotified();
++			//subState.setNotified();
+ 			mObserver.pollResultAvailable(pub.getSessionId());
+ 		}
+ 	}
+@@ -849,15 +849,16 @@ public class SubscriptionService {
+ 			
+ 			if (sreq.maxSizeGiven())
+ 				maxSize = sreq.getMaxResultSize();
+-			
+-			if (size > maxSize) {
+-				pollResult.removeResultsOf(name);
+-				pollResult.addErrorResult(name);
+-				sub.setExceededSize();
+-				clearContainers(sub);
+-				sLogger.trace(sName + ": Subscription " + name + " of " + 
++		        if (mConf.getDefaultDropOnResultsTooBig()) {	
++			        if (size > maxSize) {
++				        pollResult.removeResultsOf(name);
++				        pollResult.addErrorResult(name);
++				        sub.setExceededSize();
++				        clearContainers(sub);
++				        sLogger.trace(sName + ": Subscription " + name + " of " + 
+ 						pub.getPublisherId() + " grew too big");
+-			}
++			        }
++                        }
+ 		}
+ 	}
+ 
+@@ -872,7 +873,7 @@ public class SubscriptionService {
+ 			
+ 			
+ 			if (subState.isPollResultsTooBig()) {
+-				sLogger.trace(sName + ": " + pub.getPublisherId() + 
++				sLogger.debug(sName + ": " + pub.getPublisherId() + 
+ 						" PollResult grew too big (was=" + pr.getByteCount() + 
+ 						"bytes allowed=" + subState.getMaxPollSize() + " bytes)");
+ 				
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/BasicSearchHandler.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/BasicSearchHandler.java
+index c9ef39c..5296d7b 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/BasicSearchHandler.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/BasicSearchHandler.java
+@@ -221,6 +221,9 @@ class BasicSearchHandler implements SearchHandler {
+ 	 * @param toAdd
+ 	 */
+ 	private void appendToResult(GraphElement ge, List<Metadata> toAdd) {
++		for (Metadata md : toAdd) {
++		     sLogger.debug("appendToResult: " + md.getMetadataAsString() + "\n");
++                }
+ 		mResult.addMetadata(ge, toAdd);
+ 	}
+ 	private void appendToBeVisited(GraphElement ge) {
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiablePollResult.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiablePollResult.java
+index 0c12488..cd5bd17 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiablePollResult.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiablePollResult.java
+@@ -40,7 +40,7 @@ public interface ModifiablePollResult extends PollResult {
+ 	 * 
+ 	 * @param res
+ 	 */	
+-	public void addSearchResult(ModifiableSearchResult res);
++	public void addSearchResult(ModifiableSearchResult res, Integer mpprs);
+ 	
+ 	public void removeResultsOf(String name);
+ }
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiableSearchResult.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiableSearchResult.java
+index 3499109..d75b478 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiableSearchResult.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/ModifiableSearchResult.java
+@@ -36,7 +36,7 @@ import de.fhhannover.inform.iron.mapserver.datamodel.meta.Metadata;
+  *
+  */
+ public interface ModifiableSearchResult extends SearchResult {
+-	
++
+ 	/**
+ 	 * Add a {@link Metadata} instance to a {@link ResultItem} created
+ 	 * from the {@link GraphElement}.
+@@ -67,4 +67,8 @@ public interface ModifiableSearchResult extends SearchResult {
+ 	
+ 	public void addResultItems(List<ResultItem> rilist);
+ 
++        public void setSearchTypeInitialRun(boolean isInitialRun);
++
++        public boolean isSearchTypeInitialRun();
++
+ }
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/PollResultImpl.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/PollResultImpl.java
+index d6907a4..e2ce43f 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/PollResultImpl.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/PollResultImpl.java
+@@ -24,11 +24,16 @@ package de.fhhannover.inform.iron.mapserver.datamodel.search;
+ import java.util.ArrayList;
+ import java.util.Collections;
+ import java.util.List;
++import org.apache.log4j.Logger;
+ 
++import de.fhhannover.inform.iron.mapserver.datamodel.DataModelService;
+ import de.fhhannover.inform.iron.mapserver.IfmapConstStrings;
+ import de.fhhannover.inform.iron.mapserver.utils.CollectionHelper;
+ import de.fhhannover.inform.iron.mapserver.utils.LengthCheck;
+ import de.fhhannover.inform.iron.mapserver.utils.NullCheck;
++import de.fhhannover.inform.iron.mapserver.datamodel.search.SearchingFactory;
++import de.fhhannover.inform.iron.mapserver.datamodel.search.SearchingFactoryImpl;
++import de.fhhannover.inform.iron.mapserver.provider.LoggingProvider;
+ 
+ /**
+  * Implementation to create {@link PollResult} objects with some logic to
+@@ -45,11 +50,14 @@ class PollResultImpl implements ModifiablePollResult {
+ 	private List<ModifiableSearchResult> mResults;
+ 	private List<String> mErrors;
+ 	private int mCurSize;
++        private final SearchingFactory mSearchFac;
++        private static Logger sLogger = LoggingProvider.getTheLogger();
+ 
+ 	PollResultImpl() {
+ 		mResults = CollectionHelper.provideListFor(ModifiableSearchResult.class);
+ 		mErrors = CollectionHelper.provideListFor(String.class);
+ 		mCurSize = 0;
++                mSearchFac = SearchingFactoryImpl.newInstance();
+ 	}
+ 	
+ 	/* (non-Javadoc)
+@@ -93,24 +101,76 @@ class PollResultImpl implements ModifiablePollResult {
+ 	 * @see de.fhhannover.inform.iron.mapserver.datamodel.search.ModifiablePollResult#addSearchResult(de.fhhannover.inform.iron.mapserver.datamodel.search.ModifiableSearchResult)
+ 	 */
+ 	@Override
+-	public void addSearchResult(ModifiableSearchResult sres) {
++	public void addSearchResult(ModifiableSearchResult sres, Integer mpprs) {
++                sLogger.debug("addSearchResult: name: " + sres.getName() + ", mpprs: " + mpprs + ", byte count: " + sres.getByteCount());
+ 		NullCheck.check(sres, "sres is null");
+ 		NullCheck.check(sres.getName(), "sres.getName() is null");
+ 		LengthCheck.checkMinMax(sres.getName(), 1, 20, "sub name bad");
+ 		
+ 		ModifiableSearchResult lastResult = null;
+ 		
+-		if (mResults.size() > 0)
+-			lastResult = mResults.get(mResults.size() - 1);
+-		
+-		if (lastResult != null && sameAsLastResult(sres, lastResult)) {
+-			mCurSize -= lastResult.getByteCount();
+-			lastResult.addResultItems(sres.getResultItems());
+-		} else {
+-			mResults.add(sres);
+-			lastResult = sres;
+-		}
+-		mCurSize += lastResult.getByteCount();
++                if (mResults.size() > 0) {
++                        lastResult = mResults.get(mResults.size() - 1);
++                        sLogger.debug("lastResult size: " + lastResult.getByteCount());
++                }
++                 
++                if (sres.isSearchTypeInitialRun() && !DataModelService.getServerConfiguration().getDefaultSplitInitialSearchResult()) {
++                        sLogger.debug("isSearchTypeInitialRun: true, split is not true");
++                        if (lastResult != null && sameAsLastResult(sres, lastResult)) {
++                               mCurSize -= lastResult.getByteCount();
++                               lastResult.addResultItems(sres.getResultItems());
++                        } else {
++                               mResults.add(sres);
++                               lastResult = sres;
++                        }
++                        mCurSize += lastResult.getByteCount();
++                        return;
++                }
++
++                if (lastResult != null && sameAsLastResult(sres, lastResult)) {
++                        /* we may need to add more items to the last result */
++                        mCurSize -= lastResult.getByteCount();
++                        if ((lastResult.getByteCount() + sres.getByteCount()) < mpprs) {
++                               lastResult.addResultItems(sres.getResultItems());
++                                /* add new byte count */
++                               mCurSize += lastResult.getByteCount();
++                        } else {
++                                for (ResultItem ri : sres.getResultItems()) {
++                                    if (lastResult.getByteCount() >= mpprs) {
++                                        mCurSize += lastResult.getByteCount();
++                                        ModifiableSearchResult newResult = mSearchFac.newCopySearchResult(sres.getName(), sres.getType());
++                                        newResult.setSearchTypeInitialRun(sres.isSearchTypeInitialRun());
++                                        sLogger.debug("result entry size exeeded(" + lastResult.getByteCount() + "), split. adding a new result entry");
++                                        mResults.add(newResult);
++                                        lastResult = newResult;
++                                    }
++                                    lastResult.addResultItem(ri);
++                                }
++                                mCurSize += lastResult.getByteCount();
++                        }
++                } else {
++                        if (sres.getByteCount() <= mpprs) {
++                                mResults.add(sres);
++                                lastResult = sres;
++                                mCurSize += lastResult.getByteCount();
++                        } else {
++                                sLogger.debug("Passed result entry size exeeded(" + sres.getByteCount() + "), split. adding a new result entry");
++                                lastResult = mSearchFac.newCopySearchResult(sres.getName(), sres.getType());
++                                lastResult.setSearchTypeInitialRun(sres.isSearchTypeInitialRun());
++                                mResults.add(lastResult);
++                                for (ResultItem ri : sres.getResultItems()) {
++                                    if (lastResult.getByteCount() >= mpprs) {
++                                        mCurSize += lastResult.getByteCount();
++                                        sLogger.debug("result entry size exeeded(" + lastResult.getByteCount() + "), split. adding a new result entry");
++                                        lastResult = mSearchFac.newCopySearchResult(sres.getName(), sres.getType());
++                                        lastResult.setSearchTypeInitialRun(sres.isSearchTypeInitialRun());
++                                        mResults.add(lastResult);
++                                    }
++                                    lastResult.addResultItem(ri);
++                                }
++                                mCurSize += lastResult.getByteCount();
++                        }
++                }
+ 	}
+ 
+ 	/* (non-Javadoc)
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SearchResultImpl.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SearchResultImpl.java
+index 4c3e117..c09108e 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SearchResultImpl.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SearchResultImpl.java
+@@ -51,6 +51,11 @@ abstract class SearchResultImpl implements ModifiableSearchResult {
+ 	 */
+ 	private final SearchResultType mType;
+ 
++        /**
++         * mIsSearchTypeInitial indicates whether a SearchResult is a result of initial search or not
++         */
++        public boolean mIsSearchTypeInitial;
++
+ 	/**
+ 	 * Represents the ordered list of {@link ResultItem} objects.
+ 	 */
+@@ -84,6 +89,7 @@ abstract class SearchResultImpl implements ModifiableSearchResult {
+ 		mType = type;
+ 		mResultItems = CollectionHelper.provideListFor(ResultItem.class);
+ 		mLastResultItem = null;
++                mIsSearchTypeInitial = false;
+ 	}
+ 	
+ 	/**
+@@ -127,7 +133,22 @@ abstract class SearchResultImpl implements ModifiableSearchResult {
+ 	public final SearchResultType getType() {
+ 		return mType;
+ 	}
+-	
++
++	/* (non-Javadoc)
++	 * @see de.fhhannover.inform.iron.mapserver.datamodel.search.SearchResult#setSearchTypeInitialRun()
++	 */
++	@Override
++	public final void setSearchTypeInitialRun(boolean isInitialRun) {
++		mIsSearchTypeInitial = isInitialRun;
++	}
++
++	/* (non-Javadoc)
++	 * @see de.fhhannover.inform.iron.mapserver.datamodel.search.SearchResult#getSearchType()
++	 */
++	@Override
++	public final boolean isSearchTypeInitialRun() {
++		return mIsSearchTypeInitial;
++	}
+ 
+ 	/* (non-Javadoc)
+ 	 * @see de.fhhannover.inform.iron.mapserver.datamodel.search.SearchResult#isEmpty()
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionState.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionState.java
+index 02f4939..079d6bc 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionState.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionState.java
+@@ -27,10 +27,15 @@ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ 
++import org.apache.log4j.Logger;
++
++import de.fhhannover.inform.iron.mapserver.datamodel.DataModelService;
+ import de.fhhannover.inform.iron.mapserver.IfmapConstStrings;
+ import de.fhhannover.inform.iron.mapserver.datamodel.Publisher;
+ import de.fhhannover.inform.iron.mapserver.exceptions.SystemErrorException;
+ import de.fhhannover.inform.iron.mapserver.utils.NullCheck;
++import de.fhhannover.inform.iron.mapserver.provider.LoggingProvider;
++
+ 
+ /**
+  * Class to encapsulate all state concerning subscriptions for a single
+@@ -42,11 +47,13 @@ public class SubscriptionState {
+ 	
+ 	private boolean mNotified;
+ 	private Integer  maxPollResultSize;
++        private Integer  maxPerPollResultSize;
+ 	private boolean mPollResGrewTooBig;
+ 	
+ 	private final Map<String, Subscription> mSubscriptions;
+ 	private ModifiablePollResult mPollResult;
+-	
++        private static Logger sLogger = LoggingProvider.getTheLogger();
++
+ 	public SubscriptionState() {
+ 		mSubscriptions = new HashMap<String, Subscription>();
+ 		mPollResult = new PollResultImpl();
+@@ -128,6 +135,14 @@ public class SubscriptionState {
+ 	public void setMaxPollResultSize(Integer mprs) {
+ 		maxPollResultSize = mprs;
+ 	}
++
++        public Integer getMaxPerPollResultSize() {
++                return maxPerPollResultSize;
++        }
++
++        public void setMaxPerPollResultSize(Integer mpprs) {
++                maxPerPollResultSize = mpprs;
++        }
+ 	
+ 	public void setNotified() {
+ 		mNotified = true;
+@@ -150,11 +165,15 @@ public class SubscriptionState {
+ 	}
+ 	
+ 	public boolean isPollResultsTooBig() {
+-		if (mPollResult.getByteCount() > getMaxPollSize())
+-			mPollResGrewTooBig = true;
+-		
+-		return (mPollResult.getByteCount() > getMaxPollSize())
+-				|| mPollResGrewTooBig;
++                if (DataModelService.getServerConfiguration().getDefaultDropOnResultsTooBig()) {
++                        sLogger.debug("isPollResultsTooBig: drop results set true");
++                        if (mPollResult.getByteCount() > getMaxPollSize())
++                                mPollResGrewTooBig = true;
++                        sLogger.debug("isPollResultsTooBig: is too big: " + (mPollResult.getByteCount() > getMaxPollSize()));
++                        return (mPollResult.getByteCount() > getMaxPollSize())
++                                       || mPollResGrewTooBig;
++                }
++                return false;
+ 	}
+ 	
+ 	public void resetPollResult() {
+diff --git a/src/de/fhhannover/inform/iron/mapserver/messages/NewSessionRequest.java b/src/de/fhhannover/inform/iron/mapserver/messages/NewSessionRequest.java
+index 35c60a8..0765a7d 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/messages/NewSessionRequest.java
++++ b/src/de/fhhannover/inform/iron/mapserver/messages/NewSessionRequest.java
+@@ -48,15 +48,21 @@ import de.fhhannover.inform.iron.mapserver.exceptions.AccessDeniedException;
+ public class NewSessionRequest extends Request {
+  
+ 	private final Integer maxPollResultSize;
++	private final Integer maxPerPollResultSize;
+ 	
+-	NewSessionRequest(Integer maxpollsize) {
++	NewSessionRequest(Integer maxpollsize, Integer maxperpollsize) {
+ 		maxPollResultSize = maxpollsize;
++                maxPerPollResultSize = maxperpollsize;
+ 	}
+ 	
+ 	public Integer getMaxPollResultSize() {
+ 		return maxPollResultSize;
+ 	}
+ 
++        public Integer getMaxPerPollResultSize() {
++                return maxPerPollResultSize;
++        }
++
+ 	@Override
+ 	public void dispatch(EventProcessor ep) throws AccessDeniedException {
+ 		ep.processNewSessionRequest(this);
+diff --git a/src/de/fhhannover/inform/iron/mapserver/messages/RequestFactory.java b/src/de/fhhannover/inform/iron/mapserver/messages/RequestFactory.java
+index 4b74196..dda809d 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/messages/RequestFactory.java
++++ b/src/de/fhhannover/inform/iron/mapserver/messages/RequestFactory.java
+@@ -102,8 +102,8 @@ public class RequestFactory {
+ 		return new PurgePublisherRequest(sessionId, publisherId);
+ 	}
+ 	 
+-	public NewSessionRequest createNewSessionRequest(Integer mprs) throws RequestCreationException {
+-		return new NewSessionRequest(mprs);
++	public NewSessionRequest createNewSessionRequest(Integer mprs, Integer mpprs) throws RequestCreationException {
++		return new NewSessionRequest(mprs, mpprs);
+ 	}
+ 	 
+ 	public EndSessionRequest createEndSessionRequest(String sessionId)
+diff --git a/src/de/fhhannover/inform/iron/mapserver/provider/DataModelServerConfigurationProvider.java b/src/de/fhhannover/inform/iron/mapserver/provider/DataModelServerConfigurationProvider.java
+index a9d97c8..a575d7d 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/provider/DataModelServerConfigurationProvider.java
++++ b/src/de/fhhannover/inform/iron/mapserver/provider/DataModelServerConfigurationProvider.java
+@@ -50,8 +50,22 @@ public interface DataModelServerConfigurationProvider {
+ 	 * @return default max poll result size to be used
+ 	 */
+ 	public int getDefaultMaxPollResultSize();
+-	
+ 
++        /**
++         * @return default max per poll result size to be used
++         */
++        public int getDefaultMaxPerPollResultSize();
++
++        /**
++         * @return default boolean flag to allow or not to split initial search result 
++         */
++        public boolean getDefaultSplitInitialSearchResult();
++ 
++        /**
++         * @return default boolean flag to drop or not to drop search result if too big
++         */
++        public boolean getDefaultDropOnResultsTooBig();
++ 
+ 	/**
+ 	 * @return the number of bytes used as default max search result size
+ 	 */
+diff --git a/src/de/fhhannover/inform/iron/mapserver/provider/ServerConfigurationProviderPropImpl.java b/src/de/fhhannover/inform/iron/mapserver/provider/ServerConfigurationProviderPropImpl.java
+index ad452ac..f53b639 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/provider/ServerConfigurationProviderPropImpl.java
++++ b/src/de/fhhannover/inform/iron/mapserver/provider/ServerConfigurationProviderPropImpl.java
+@@ -68,7 +68,16 @@ public class ServerConfigurationProviderPropImpl implements ServerConfigurationP
+ 	
+ 	private static final String IFMAP_DEF_MAX_POLL_RES_SIZE_KEY = PROP_PREFIX + "ifmap.default.maxpollresultsize";
+ 	private static final String IFMAP_DEF_MAX_POLL_RES_SIZE_DEFAULT = "5000000";
+-
++
++        private static final String IFMAP_DEF_MAX_PER_POLL_RES_SIZE_KEY = PROP_PREFIX + "ifmap.default.maxperpollresultsize";
++        private static final String IFMAP_DEF_MAX_PER_POLL_RES_SIZE_DEFAULT = "8192";
++
++        private static final String IFMAP_DEF_SPLIT_INITIAL_SEARCH_KEY = PROP_PREFIX + "ifmap.default.splitinitialsearchresult";
++        private static final String IFMAP_DEF_SPLIT_INITIAL_SEARCH_DEFAULT = "false";
++
++        private static final String IFMAP_DEF_DROP_ON_RESULTS_TOO_BIG_KEY = PROP_PREFIX + "ifmap.default.droponresultstoobig";
++        private static final String IFMAP_DEF_DROP_ON_RESULTS_TOO_BIG_DEFAULT = "true";
++
+ 	private static final String IFMAP_DEF_MAX_SEARCH_RES_SIZE_KEY = PROP_PREFIX + "ifmap.default.searchresultsize";
+ 	private static final String IFMAP_DEF_MAX_SEARCH_RES_SIZE_DEFAULT = "100000";
+ 
+@@ -186,6 +195,26 @@ public class ServerConfigurationProviderPropImpl implements ServerConfigurationP
+ 		return Integer.parseInt(val);
+ 	}
+ 
++        @Override
++        public int getDefaultMaxPerPollResultSize() {
++               String val = getOrSetDefaultAndGet(IFMAP_DEF_MAX_PER_POLL_RES_SIZE_KEY,
++                               IFMAP_DEF_MAX_PER_POLL_RES_SIZE_DEFAULT);
++               // this throws an exception if it goes wrong, but i'm fine with that
++               return Integer.parseInt(val);
++        }
++
++        @Override
++        public boolean getDefaultSplitInitialSearchResult() {
++               return new Boolean(getOrSetDefaultAndGet(IFMAP_DEF_SPLIT_INITIAL_SEARCH_KEY,
++                               IFMAP_DEF_SPLIT_INITIAL_SEARCH_DEFAULT));
++        }
++
++        @Override
++        public boolean getDefaultDropOnResultsTooBig() {
++               return new Boolean(getOrSetDefaultAndGet(IFMAP_DEF_DROP_ON_RESULTS_TOO_BIG_KEY,
++                               IFMAP_DEF_DROP_ON_RESULTS_TOO_BIG_DEFAULT));
++        }
++
+ 	@Override
+ 	public int getDefaultMaxSearchResultSize() {
+ 		String val = getOrSetDefaultAndGet(IFMAP_DEF_MAX_SEARCH_RES_SIZE_KEY, 
+diff --git a/src/org/trustedcomputinggroup/_2010/ifmap/_2/NewSessionRequestType.java b/src/org/trustedcomputinggroup/_2010/ifmap/_2/NewSessionRequestType.java
+index 7adbf5c..541ec49 100644
+--- a/src/org/trustedcomputinggroup/_2010/ifmap/_2/NewSessionRequestType.java
++++ b/src/org/trustedcomputinggroup/_2010/ifmap/_2/NewSessionRequestType.java
+@@ -38,6 +38,8 @@ public class NewSessionRequestType {
+ 
+     @XmlAttribute(name = "max-poll-result-size")
+     protected BigInteger maxPollResultSize;
++    @XmlAttribute(name = "max-per-poll-result-size")
++    protected BigInteger maxPerPollResultSize;
+ 
+     /**
+      * Gets the value of the maxPollResultSize property.
+@@ -62,5 +64,27 @@ public class NewSessionRequestType {
+     public void setMaxPollResultSize(BigInteger value) {
+         this.maxPollResultSize = value;
+     }
++    /**
++     * Gets the value of the maxPollResultSize property.
++     * 
++     * @return
++     *     possible object is
++     *     {@link BigInteger }
++     *     
++     */
++    public BigInteger getMaxPerPollResultSize() {
++        return maxPerPollResultSize;
++    }
+ 
++    /**
++     * Sets the value of the maxPollResultSize property.
++     * 
++     * @param value
++     *     allowed object is
++     *     {@link BigInteger }
++     *     
++     */
++    public void setMaxPerPollResultSize(BigInteger value) {
++        this.maxPerPollResultSize = value;
++    }
+ }


### PR DESCRIPTION
Poll results must be segmented since the control-node issues query for the root object on session establishment. When large databases are used (+n K VMs) this results in 10s of megabytes of data.
