### PR TITLE
Fix directory to allow packages to build

### DIFF
--- a/debian/opencontrail/debian/rules
+++ b/debian/opencontrail/debian/rules
@@ -2,7 +2,7 @@
 # -*- makefile -*-
 
 export INSTALL_ROOT=$(shell pwd)
-SB_TOP := $(shell pwd | sed -re "s/(.*)\/build\/packages/\1/")
+SB_TOP := $(shell pwd | sed -re "s/(.*)\/build\/packages\/opencontrail/\1/")
 
 export LD_LIBRARY_PATH := $(LD_LIBRARY_PATH):$(INSTALL_ROOT)/usr/lib
 


### PR DESCRIPTION
I think this is a bug in the sed script that was preventing packages from building since it would always precede the path with '.*' which isn't a thing
