### PR TITLE
[ifmap-server]add link to java classpath

### DIFF
--- a/packages.make
+++ b/packages.make
@@ -9,6 +9,7 @@ package-ifmap-server: debian-ifmap-server
 	$(eval PACKAGE := $(patsubst package-%,%,$@))
 	@echo "Building package $(PACKAGE)"
 	(cd build/packages/$(PACKAGE); fakeroot debian/rules get-orig-source)
+	(cd build/packages/$(PACKAGE); ln -s /usr/share/java lib)
 	(cd build/packages/$(PACKAGE); fakeroot debian/rules binary)
 
 package-%: debian-%


### PR DESCRIPTION
Build fail at ifmap-server.
Because ifmap-server require to contain library in "lib".
