### PR TITLE
[upstart] Update upstart configurations (user/start-stop-daemon)

### DIFF
--- a/debian/contrail/debian/contrail-compute.upstart
+++ b/debian/contrail/debian/contrail-compute.upstart
@@ -5,10 +5,11 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/vnswad"
-  CONF="/etc/contrail/agent.conf"
+  CONF="/etc/contrail/contrail-vrouter-agent.conf"
   USER="contrail"
   OPTS="--config-file ${CONF}"
 
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 

--- a/debian/contrail/debian/contrail-config.contrail-api.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-api.upstart
@@ -5,6 +5,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/contrail-api"
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 

--- a/debian/contrail/debian/contrail-config.contrail-discovery.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-discovery.upstart
@@ -5,6 +5,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/discovery-server"
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 

--- a/debian/contrail/debian/contrail-config.contrail-schema.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-schema.upstart
@@ -5,6 +5,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/contrail-schema"
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 

--- a/debian/contrail/debian/contrail-config.contrail-svc-monitor.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-svc-monitor.upstart
@@ -5,6 +5,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/contrail-svc-monitor"
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 

--- a/debian/contrail/debian/contrail-control.contrail-dns.upstart
+++ b/debian/contrail/debian/contrail-control.contrail-dns.upstart
@@ -5,6 +5,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/dnsd"
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 

--- a/debian/contrail/debian/contrail-control.upstart
+++ b/debian/contrail/debian/contrail-control.upstart
@@ -5,6 +5,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/control-node"
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 

--- a/debian/ifmap-server/debian/ifmap-server.upstart
+++ b/debian/ifmap-server/debian/ifmap-server.upstart
@@ -5,6 +5,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 chdir /var/run
+respawn
 
 script
   COMMAND="/usr/bin/ifmap-server"
@@ -18,7 +19,7 @@ script
   fi
 
   if ! [ -r "$CONF" ] ; then
-    echo "Cloud not read ${CONF}: exiting"
+    echo "Could not read ${CONF}: exiting"
     exit 0
   fi
 


### PR DESCRIPTION
- Introduce 4 parameters in all upstart jobs:
  - COMMAND: Command to run
  - CONF: The configuration file to use
  - USER: Which user to run (user/group)
  - OPTS: Options to pass to COMMAND (default to --config{-,_}file)
- Verify the presence of the configuration file before start
- Allow override of the 4 params with /etc/default/«daemon-name»
- Run Contrail\* as contrail (a non privileged user)
- Use start-stop-daemon to launch jobs

Change-Id: I1783540cd8218e8bafb4d0b860ca4c5992f35a19
