### PR TITLE
[pydist-overrides] Remove zc-zookeeper-static

### DIFF
--- a/debian/contrail/debian/pydist-overrides
+++ b/debian/contrail/debian/pydist-overrides
@@ -1,4 +1,3 @@
-zc_zookeeper_static python-zookeeper
 pycassa python-pycassa
 geventhttpclient python-geventhttpclient
 gevent python-gevent


### PR DESCRIPTION
https://github.com/Juniper/contrail-controller/commit/0a947531f55bf41095a1fed0918df26109a2728b
