### PR TITLE
Fix upstart options (all daemon use --conf_file)

### DIFF
--- a/debian/contrail/debian/contrail-analytics.contrail-analytics-api.upstart
+++ b/debian/contrail/debian/contrail-analytics.contrail-analytics-api.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/contrail-analytics-api"
   CONF="/etc/contrail/contrail-analytics-api.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-analytics.contrail-collector.upstart
+++ b/debian/contrail/debian/contrail-analytics.contrail-collector.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/contrail-collector"
   CONF="/etc/contrail/contrail-collector.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-analytics.contrail-query-engine.upstart
+++ b/debian/contrail/debian/contrail-analytics.contrail-query-engine.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/contrail-query-engine"
   CONF="/etc/contrail/contrail-query-engine.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-config.contrail-api.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-api.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/contrail-api"
   CONF="/etc/contrail/contrail-api.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-config.contrail-discovery.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-discovery.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/discovery-server"
   CONF="/etc/contrail/discovery.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-config.contrail-schema.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-schema.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/contrail-schema"
   CONF="/etc/contrail/contrail-schema.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-config.contrail-svc-monitor.upstart
+++ b/debian/contrail/debian/contrail-config.contrail-svc-monitor.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/contrail-svc-monitor"
   CONF="/etc/contrail/svc-monitor.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-control.contrail-dns.upstart
+++ b/debian/contrail/debian/contrail-control.contrail-dns.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/dnsd"
   CONF="/etc/contrail/dns.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/debian/contrail/debian/contrail-control.upstart
+++ b/debian/contrail/debian/contrail-control.upstart
@@ -11,7 +11,7 @@ script
   COMMAND="/usr/bin/control-node"
   CONF="/etc/contrail/control-node.conf"
   USER="contrail"
-  OPTS="--config_file ${CONF}"
+  OPTS="--conf_file ${CONF}"
 
   # Allow override of command/conf and opts by /etc/default/daemon-name
   if [ -f /etc/default/$UPSTART_JOB ]; then


### PR DESCRIPTION
All except vnswad (--config_file).
A LP bug is opened for rename --conf_file to --conf-file
https://bugs.launchpad.net/opencontrail/+bug/1311408
