### PR TITLE
install issue: delete version of contrail-vrouter

### DIFF
--- a/debian/contrail/debian/control
+++ b/debian/contrail/debian/control
@@ -122,7 +122,7 @@ Description: OpenContrail control-node
 
 Package: contrail-vrouter-agent
 Depends: contrail-lib (= ${binary:Version}),
-         contrail-vrouter (= ${binary:Version}),
+         contrail-vrouter,
          ${misc:Depends},
          ${shlib:Depends}
 Architecture: any


### PR DESCRIPTION
contrail-vrouter is virtual package.
it has no version.
