### PR TITLE
Fix roon call on « old » ubuntu 12.04LTS…

### DIFF
--- a/debian/contrail/debian/manpages/contrail-api.ronn
+++ b/debian/contrail/debian/manpages/contrail-api.ronn
@@ -111,7 +111,7 @@ OpenContrail developers <dev@lists.opencontrail.org>
 
 ## COPYRIGHT
 
-Copyright © 2014 OpenContrail
+Copyright (c) 2014 OpenContrail
 
 ## SEE ALSO
 

--- a/debian/contrail/debian/manpages/contrail-schema.ronn
+++ b/debian/contrail/debian/manpages/contrail-schema.ronn
@@ -27,7 +27,7 @@ OpenContrail developers <dev@lists.opencontrail.org>
 
 ## COPYRIGHT
 
-Copyright © 2014 OpenContrail
+Copyright (c) 2014 OpenContrail
 
 ## SEE ALSO
 

--- a/debian/contrail/debian/manpages/contrail-svc-monitor.ronn
+++ b/debian/contrail/debian/manpages/contrail-svc-monitor.ronn
@@ -27,7 +27,7 @@ OpenContrail developers <dev@lists.opencontrail.org>
 
 ## COPYRIGHT
 
-Copyright © 2014 OpenContrail
+Copyright (c) 2014 OpenContrail
 
 ## SEE ALSO
 

--- a/debian/contrail/debian/manpages/discovery-server.ronn
+++ b/debian/contrail/debian/manpages/discovery-server.ronn
@@ -27,7 +27,7 @@ OpenContrail developers <dev@lists.opencontrail.org>
 
 ## COPYRIGHT
 
-Copyright © 2014 OpenContrail
+Copyright (c) 2014 OpenContrail
 
 ## SEE ALSO
 


### PR DESCRIPTION
/usr/lib/ruby/vendor_ruby/ronn/document.rb:192:in
`split': invalid byte sequence in US-ASCII (ArgumentError)`
