### PR TITLE
[ifmap-server] Fix debian/changelog version

### DIFF
--- a/debian/ifmap-server/debian/changelog
+++ b/debian/ifmap-server/debian/changelog
@@ -5,8 +5,7 @@ ifmap-server (0.3.2-1contrail1) precise; urgency=low
 
  -- Pedro Marques <roque@juniper.net>  Fri, 2 Apr 2014 17:15:00 -0800
 
-
-ifmap-server (0.3.2-2) precise; urgency=low
+ifmap-server (0.3.2-1) precise; urgency=low
 
   * Initial release.
 


### PR DESCRIPTION
the current version (0.3.2-1contrail1) is earlier than the previous one (0.3.2-2)
