### PR TITLE
[backport 1.06][ifmap-server] Add missing dependency on java

### DIFF
--- a/debian/ifmap-server/debian/control
+++ b/debian/ifmap-server/debian/control
@@ -18,7 +18,8 @@ Homepage: https://github.com/trustathsh/irond/
 Package: ifmap-server
 Architecture: all
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libcommons-codec-java,
+Depends: default-jre-headless | java-runtime-headless,
+         libcommons-codec-java,
          libhttpcore-java,
          liblog4j1.2-java,
          ${java:Depends},


### PR DESCRIPTION
> apt-cache show ifmap-server |grep Depends
> Depends: libcommons-codec-java, libhttpcore-java, liblog4j1.2-java, upstart-job
> Pre-Depends: dpkg (>= 1.15.6~)
> apt-cache policy ifmap-server
>   ifmap-server:
>   Installed: (none)
>   Candidate: 0.3.2-1contrail1
>   Version table:
>      0.3.2-1contrail1 0
>         500 http://ppa.launchpad.net/opencontrail/ppa/ubuntu/ precise/main amd64 Packages
