### PR TITLE
Fix contrail config openstack

### DIFF
--- a/debian/contrail/debian/control
+++ b/debian/contrail/debian/control
@@ -102,8 +102,6 @@ Description: OpenContrail configuration management
 Package: contrail-config-openstack
 Architecture: all
 Depends: contrail-config (= ${source:Version}),
-         python-bottle (>= 0.11.6),
-         python-contrail (= ${source:Version}),
          python-keystoneclient,
          python-novaclient,
          ${misc:Depends},


### PR DESCRIPTION
- python-config doesn't exist…
- python-{bottle,contrail} are already managed by contrail-config.
