### PR TITLE
opencontrail: Remove python:version (typo??)

### DIFF
--- a/debian/contrail/debian/control
+++ b/debian/contrail/debian/control
@@ -105,8 +105,7 @@ Depends: contrail-config (= ${source:Version}),
          python-keystoneclient,
          python-novaclient,
          ${misc:Depends},
-         ${python:Depends},
-         ${python:Versions}
+         ${python:Depends}
 Description: OpenContrail configuration OpenStack module
  This package contains the configuration management modules that interface
  with OpenStack.


### PR DESCRIPTION
e54d60efa62ee5a74ecb9b5b6484c92be73760bf

```
Depends: contrail-config (= 1.06-1-2014051407331), python-keystoneclient, python-novaclient, upstart-job, python:any (<< 2.8), python, python-zope.interface, python:any (>= 2.7.3-0ubuntu2~), 2.7
```
