### PR TITLE
Revert "neutron-plugin: install contrail configuration"

### DIFF
--- a/debian/neutron-plugin-contrail/debian/neutron-plugin-contrail.install
+++ b/debian/neutron-plugin-contrail/debian/neutron-plugin-contrail.install
@@ -1,3 +1,2 @@
 etc/neutron/plugins
-etc/contrail
 usr/lib/python*/dist-packages/neutron*


### PR DESCRIPTION
This reverts commit 31579b1182f0e149aea6c0714460e3f6a7f94bf0.
This part of code is now managed by python-contrail package
see https://github.com/Juniper/contrail-neutron-plugin/pull/11#commitcomment-6351451
