### PR TITLE
contrail: Switch zookeeper and cassandra from suggest to recommends

### DIFF
--- a/debian/contrail/debian/control
+++ b/debian/contrail/debian/control
@@ -40,7 +40,7 @@ Depends: adduser,
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends}
-Suggests: cassandra, redis-server (>= 2.6.13-1)
+Recommends: cassandra, redis-server (>= 2.6.13-1)
 Description: OpenContrail analytics
  Analytics nodes are responsible for collecting, collating and presenting
  analytics information for trouble shooting problems and for understanding
@@ -78,7 +78,7 @@ Depends: adduser,
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends}
-Suggests: cassandra, zookeeper
+Recommends: cassandra, zookeeper
 Description: OpenContrail configuration management
  Configuration nodes are responsible for the management layer. The
  configuration nodes provide a north-bound Representational State Transfer


### PR DESCRIPTION
Recommends
  This declares a strong, but not absolute, dependency.
  The Recommends field should list packages that would be found
  together with this one in all but unusual installations.

Suggests
  This is used to declare that one package may be more useful with one
  or more others. Using this field tells the packaging system and the user
  that the listed packages are related to this one and can perhaps enhance
  its usefulness, but that installing this one without them is perfectly
  reasonable.

From https://www.debian.org/doc/debian-policy/ch-relationships.html
