### PR TITLE
contrail-control: Fix control upstart job

### DIFF
--- a/debian/contrail/debian/contrail-control.postinst
+++ b/debian/contrail/debian/contrail-control.postinst
@@ -20,6 +20,12 @@ if [ "$1" = "configure" ] || [ "$1" = "reconfigure" ] ; then
   chown -R contrail:contrail /var/lib/contrail/ /etc/contrail/
   chmod 0750 /etc/contrail/
 
+  # Use authbind to bind contrail-control on a reserved port,
+  # with contrail user privileges
+  touch /etc/authbind/byport/179
+  chown contrail. /etc/authbind/byport/179
+  chmod 0755 /etc/authbind/byport/179
+
 fi
 
 #DEBHELPER#

--- a/debian/contrail/debian/contrail-control.upstart
+++ b/debian/contrail/debian/contrail-control.upstart
@@ -8,7 +8,7 @@ chdir /var/run
 respawn
 
 script
-  COMMAND="/usr/bin/control-node"
+  COMMAND="/usr/bin/authbind /usr/bin/control-node"
   CONF="/etc/contrail/control-node.conf"
   USER="contrail"
   OPTS="--conf_file ${CONF}"

--- a/debian/contrail/debian/control
+++ b/debian/contrail/debian/control
@@ -112,6 +112,7 @@ Description: OpenContrail configuration OpenStack module
 
 Package: contrail-control
 Depends: adduser,
+         authbind,
          contrail-lib (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
Contrail user isn't allowed to bind on a reserved port,
thix commit use authbind to allow contrail user (non-root), to
bind on port 179.
