### PR TITLE
contrail: Fix keystoneclient minimum depends

### DIFF
--- a/debian/contrail/debian/control
+++ b/debian/contrail/debian/control
@@ -102,7 +102,7 @@ Description: OpenContrail configuration management
 Package: contrail-config-openstack
 Architecture: all
 Depends: contrail-config (= ${source:Version}),
-         python-keystoneclient,
+         python-keystoneclient (>= 0.2.2),
          python-novaclient,
          ${misc:Depends},
          ${python:Depends}


### PR DESCRIPTION
Vnc api server us keystoneclient.middleware (auth_token), this
feature was introduced in keystoneclient in >= 0.2.2, but we have
2012.1-0ubuntu1 (essex version, pre 0.1.0) in precise.

We need to backport kestoneclient >= 0.2.2, to the PPA
