### PR TITLE
Fix source-package-ifmap-server and disable WEBUI_VERSION

### DIFF
--- a/packages.make
+++ b/packages.make
@@ -61,7 +61,7 @@ build/packages/ifmap-server_0.3.2.orig.tar.gz:
 	(cd build/packages/$(PACKAGE); fakeroot debian/rules get-orig-source)
 	(cd build/packages/$(PACKAGE); tar zcf ../ifmap-server_0.3.2.orig.tar.gz .)
 
-source-package-ifmap-server: clean-ifmap-server source-ifmap-server debian-ifmap-server
+source-package-ifmap-server: clean-ifmap-server debian-ifmap-server source-ifmap-server
 	$(eval PACKAGE := ifmap-server)
 	(cd build/packages/$(PACKAGE); dpkg-buildpackage -S -rfakeroot $(KEYOPT))
 

--- a/versions.mk
+++ b/versions.mk
@@ -7,7 +7,7 @@ ifdef VERSION
 
 CONTRAIL_VERSION = $(VERSION)
 NEUTRON_VERSION = $(VERSION)
-WEBUI_VERSION = $(VERSION)
+#WEBUI_VERSION = $(VERSION)
 
 else
 #
@@ -17,9 +17,9 @@ else
 
 CONTROLLER_REF := $(shell (cd controller; git log --oneline -1) | awk '/[0-9a-f]+/ { print $$1; }')
 NEUTRON_REF := $(shell (cd openstack/neutron_plugin; git log --oneline -1) | awk '/[0-9a-f]+/ { print $$1; }')
-WEBUI_REF := $(shell (cd contrail-web-core; git log --oneline -1) | awk '/[0-9a-f]+/ { print $$1; }')
+#WEBUI_REF := $(shell (cd contrail-web-core; git log --oneline -1) | awk '/[0-9a-f]+/ { print $$1; }')
 CONTRAIL_VERSION = 1.1master~$(CONTROLLER_REF)
 NEUTRON_VERSION = 1.1master~$(NEUTRON_REF)
-WEBUI_VERSION = 1.1master~$(WEBUI_REF)
+#WEBUI_VERSION = 1.1master~$(WEBUI_REF)
 
 endif


### PR DESCRIPTION
debian-ifmap-server target is required by source-ifmap-server and must
be run before.
Webui isn't yet ready un repo/vnc.
