### PR TITLE
[ifmap-server] Reduce loglevel of ifmap-server (default to debug…)

### DIFF
--- a/debian/ifmap-server/debian/confs/log4j.properties
+++ b/debian/ifmap-server/debian/confs/log4j.properties
@@ -1,26 +1,12 @@
-# Set root logger level to DEBUG and its only appender to CONSOLE
-log4j.rootLogger=TRACE, CONSOLE
+# Log configuration ifmap-server
+#
+log4j.rootLogger=INFO
 log4j.error
 
-log4j.logger.de.fhhannover.inform.irond.proc=TRACE, A1, A2
+log4j.logger.de.fhhannover.inform.irond.proc=INFO, A1
 log4j.additivity.de.fhhannover.inform.irond.proc=false
 
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1=org.apache.log4j.FileAppender
+log4j.appender.A1.File=/var/log/contrail/ifmap-server.log
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %x - %m%n
-
-log4j.appender.A2=org.apache.log4j.FileAppender
-log4j.appender.A2.File=/var/log/contrail/ifmap-server.log
-log4j.appender.A2.layout=org.apache.log4j.PatternLayout
-log4j.appender.A2.layout.ConversionPattern=%d [%t] %-5p %x - %m%n
-
-log4j.logger.de.fhhannover.inform.irond.rawrequests=TRACE, A3
-log4j.additivity.de.fhhannover.inform.irond.rawrequests=false
-log4j.appender.A3=org.apache.log4j.FileAppender
-log4j.appender.A3.file=/var/log/contrail/ifmap-server-raw.log
-log4j.appender.A3.layout=org.apache.log4j.PatternLayout
-log4j.appender.A3.layout.ConversionPattern=%d %-5p %x - %m%n
-
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%-8r [%t] %-5p %C{1} %x - %m%n


### PR DESCRIPTION
The default log4j configuration logs every messages to console (and then upstart), and to ifmap-server.log, debug message are sent to ifmap-server-raw.log.
This commit reduce the loglevel for a production use
