### PR TITLE
[ifmap-server] Update {owner,group}ship for ifmap config

### DIFF
--- a/debian/ifmap-server/debian/ifmap-server.postinst
+++ b/debian/ifmap-server/debian/ifmap-server.postinst
@@ -16,8 +16,9 @@ if [ "$1" = "configure" ] || [ "$1" = "reconfigure" ] ; then
 
   mkdir -p /var/log/contrail
   chown -R contrail:adm /var/log/contrail
+  chown -R contrail. /etc/contrail
   chmod 0750 /var/log/contrail
-  chown -R contrail:contrail /var/lib/contrail/
+  chown -R contrail. /var/lib/contrail/
 
 fi
 


### PR DESCRIPTION
Mentioned by Edouard, the publisher.properties config must be writeable
by the irond user (contrail).
