### PR TITLE
Fix build

### DIFF
--- a/debian/ceilometer-plugin-contrail/debian/changelog
+++ b/debian/ceilometer-plugin-contrail/debian/changelog
@@ -2,4 +2,4 @@ ceilometer-plugin-contrail (VERSION) SERIES; urgency=low
 
   * Initial release.
 
- -- Megh Bhatt <meghb@juniper.net>  Fri Feb 20 17:21:32 PST 2015
+ -- Megh Bhatt <meghb@juniper.net>  Fri, 20 Feb 2015 17:21:32 -0800

--- a/debian/contrail-heat/debian/changelog
+++ b/debian/contrail-heat/debian/changelog
@@ -2,4 +2,4 @@ contrail-heat (VERSION) SERIES; urgency=low
 
   * Initial release.
 
- -- Praneet Bachheti <praneetb@juniper.net>  Fri, 8 Oct 2014
+ -- Praneet Bachheti <praneetb@juniper.net>  Fri, 8 Oct 2014 00:00:00 -0000

--- a/debian/contrail-web-core/debian/control
+++ b/debian/contrail-web-core/debian/control
@@ -10,7 +10,7 @@ Homepage: https://github.com/Juniper/contrail-web-core/
 
 Package: contrail-web-core
 Architecture: amd64
-Depends: nodejs (= 0.8.15-1contrail1), redis-server, ${misc:Depends}
+Depends: nodejs, redis-server, ${misc:Depends}
 Description: OpenContrail WebUI Core
  OpenContrail Web UI for the management of Contrail network virtualization
  solution. This module interacts with other components of both Contrail network

--- a/debian/contrail/debian/control
+++ b/debian/contrail/debian/control
@@ -30,7 +30,7 @@ Build-Depends: autoconf,
                unzip,
                vim-common,
                libsnmp-python,
-               libipfix,
+               libipfix-dev,
                librdkafka-dev,
                librdkafka1,
                BUILDDEP_SERIES

--- a/packages.make
+++ b/packages.make
@@ -32,14 +32,24 @@ ifeq ($(SERIES),trusty)
     CONTRAIL_VROUTER_DPDK := contrail-vrouter-dpdk
 endif
 
-source-all: source-package-contrail \
-        source-package-contrail-web-core \
-        source-package-contrail-web-controller
+source-all: source-package-contrail-web-core \
+	source-package-contrail-web-controller \
+	source-package-contrail \
+	source-package-ifmap-server \
+	source-package-neutron-plugin-contrail \
+	source-package-ceilometer-plugin-contrail \
+	source-package-contrail-heat
 
-all: package-contrail \
-     package-ifmap-server \
-     package-ifmap-python-client \
-     $(CONTRAIL_VROUTER_DPDK)
+all: package-ifmap-server \
+	package-ifmap-python-client \
+	package-contrail-webui-bundle \
+	package-contrail-web-core \
+	package-contrail-web-controller \
+	package-contrail \
+	package-neutron-plugin-contrail \
+	package-ceilometer-plugin-contrail \
+	package-contrail-heat \
+	$(CONTRAIL_VROUTER_DPDK)
 
 package-ifmap-server: clean-ifmap-server debian-ifmap-server
 	$(eval PACKAGE := $(patsubst package-%,%,$@))


### PR DESCRIPTION
From https://github.com/Juniper/contrail-web-core/blob/master/README.md:

> Install the latest nodejs from https://nodejs.org/

Seems that it's not needed to enforce old nodejs anymore.

I have also fixed source-all and all makefile targets and invalid changelog file for contrail-heat package.

Also fix name of package, providing libipfix header files.

And wrongly formatted changelogs.. nobody ever tried to build this?