### PR TITLE
removing dkms.in references from contrail spec file

### DIFF
--- a/rpm/contrail/contrail.spec
+++ b/rpm/contrail/contrail.spec
@@ -92,10 +92,7 @@ mkdir -p %{buildroot}/_centos/tmp
 popd
 pushd %{buildroot}
 mkdir -p %{buildroot}/centos
-cp %{_sbtop}/%{_distropkgdir}/dkms.conf.in %{buildroot}/centos/
 (cd usr/src/vrouter && tar zcf %{buildroot}/_centos/tmp/contrail-vrouter-%{_verstr}.tar.gz .)
-sed "s/__VERSION__/"%{_verstr}"/g" centos/dkms.conf.in > usr/src/vrouter/dkms.conf
-rm  centos/dkms.conf.in
 install -d -m 755 %{buildroot}/usr/src/modules/contrail-vrouter
 install -p -m 755 %{buildroot}/_centos/tmp/contrail-vrouter*.tar.gz %{buildroot}/usr/src/modules/contrail-vrouter
 rm %{buildroot}/_centos/tmp/contrail-vrouter*.tar.gz


### PR DESCRIPTION
It appears to be copied to aplace that's not tarred up before it's removed
Not sure that it's being used?

I had to remove it to complete my rpm build. Haven't tried to deploy yet.
Maybe reply will fail because it was removed.
