### PR TITLE
Fix name for Python Fabric package

### DIFF
--- a/rpm/contrail/contrail.spec
+++ b/rpm/contrail/contrail.spec
@@ -921,8 +921,8 @@ modules/daemons.
 %package fabric-utils
 Summary: Contrail Fabric Utilities
 Group: Applications/System
+Requires: fabric
 Requires: python-yaml
-Requires: python-Fabric
 Requires: python-netaddr
 
 %description fabric-utils


### PR DESCRIPTION
- Fabric can be installed using 'fabric' as package name instead of 'python-Fabric'. Check out EPEL repository for more information about such package.