### PR TITLE
Update vrouter-functions.sh

### DIFF
--- a/rpm/contrail-vrouter-dpdk-init/vrouter-functions.sh
+++ b/rpm/contrail-vrouter-dpdk-init/vrouter-functions.sh
@@ -552,7 +552,7 @@ _dpdk_vrouter_ini_bond_info_collect() {
         -e "/^ *${VROUTER_DPDK_CMD_KEY} *=/ {
             s/slave=/\x1/g
             s/[^\x1]+//
-            s/\x1([0-9:\.]+)[^\x1]+/ \1/g
+            s/\x1([0-9a-f:\.]+)[^\x1]+/ \1/g
             p
         }" \
         ${VROUTER_DPDK_INI}`


### PR DESCRIPTION
Hexadecimal PCI addresses are not taken into account by vrouter-functions.sh
The same bug exists in other branches 3.2 & 4.x.

Below is an example of what happens in my case:
# dpdk_nic_bind.py --status
...
0000:5**e**:00.0 '82599 10 Gigabit Dual Port Backplane Connection' drv=uio_pci_generic unused=ixgbe
...

Here are log messages in /var/log/contrail.log 

++ sed -nr -e '/^ *command *=/ {
            s/slave=/\x1/g
            s/[^\x1]+//
            s/\x1([0-9:\.]+)[^\x1]+/ \1/g
            p
        }' /etc/contrail/supervisord_vrouter_files/contrail-vrouter-dpdk.ini
+ DPDK_BOND_PCIS=' 0000'
+ DPDK_BOND_PCIS=0000
...
++ grep Driver: /var/run/vrouter/0000
++ tr -d '[\n\r]'
grep: /var/run/vrouter/0000: No such file or directory